### PR TITLE
Test files have different target directories than program files when compiled (flycheck)

### DIFF
--- a/jdee-flycheck.el
+++ b/jdee-flycheck.el
@@ -212,6 +212,12 @@ file and buffer with the contents of the current buffer and compiles that one."
       (unless jdee-compile-option-directory
         (set (make-local-variable 'jdee-compile-option-directory)
              (expand-file-name "classes" dir)))
+      ;; Use jdee-compile-option-directory dir from orig-buffer if it is set
+      ;; as a local variable. When compiling a test file this dir is normally
+      ;; test-classes, not classes. Runtime classes and test classes have
+      ;; different jdee-compile-option-directory in the same project.
+      (let ((v (buffer-local-value 'jdee-compile-option-directory orig-buffer)))
+        (if v (set 'jdee-compile-option-directory v)))
 
       (setq compilation-finish-functions
             (lambda (buf msg)


### PR DESCRIPTION
When compiling a test file its target directory is normally something bellow "test-classes". Regular classes are compiled to "classes" directory. Thus regular classes and test classes have different jdee-compile-option-directory in the same project.
A solution to this issue is to make jdee-compile-option-directory a buffer local variable and set its value accordingly in prj.el . But flycheck cannot known where to put the compiled file, so the solution I propose is to copy jdee-compile-option-directory value from original buffer if it was set.

The greater goal here is to have the compiled file in the right place as maven/ant would do, without compiling it twice (one for check, other the "real" compilation).

Thanks